### PR TITLE
start work on using wandio sys crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libbgpstream-sys"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 authors = ["Brendan Horan"]
 description = "System bindings for bgpstream"
@@ -11,8 +11,10 @@ repository = "https://github.com/brendanhoran/libbgpstream-sys"
 
 [dependencies]
 rdkafka-sys = "4.5.0"
+wandio-sys = { git = "https://github.com/brendanhoran/wandio-sys.git" }
 
 [build-dependencies]
 bindgen = "0.65.1"
 autotools = "0.2"
 rdkafka-sys = "4.5.0"
+wandio-sys = { git = "https://github.com/brendanhoran/wandio-sys.git" }


### PR DESCRIPTION
[bgpstream](https://github.com/CAIDA/libbgpstream) depends on [wandio](https://github.com/brendanhoran/wandio-sys) compiled with HTTP support.
Use the sys crate to provide that functionality.

The crate is currently located at:
https://github.com/brendanhoran/wandio-sys

Sadly wandio links to the system library and I have not found a way to avoid that.
Thus this sys crate now links to system lib.
This is the line from wandio config.log
```
LIBWANDIO_LIBS=' -lpthread -lbz2 -lz -llzo2 -llzma -lzstd -llz4 -lcurl'
```