### PR TITLE
Enable Kafka support by using rdkafka-sys  crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,9 @@ documentation = "https://github.com/brendanhoran/libbgpstream-sys/blob/main/READ
 repository = "https://github.com/brendanhoran/libbgpstream-sys"
 
 [dependencies]
+rdkafka-sys = "4.5.0"
 
 [build-dependencies]
 bindgen = "0.65.1"
 autotools = "0.2"
+rdkafka-sys = "4.5.0"

--- a/vendor/change_include_path_rdkafka_check.patch
+++ b/vendor/change_include_path_rdkafka_check.patch
@@ -1,0 +1,11 @@
+--- m4/check_rdkafka_version.m4.org	2023-07-02 18:11:51.409725946 +1000
++++ m4/check_rdkafka_version.m4	2023-07-02 18:12:29.041896799 +1000
+@@ -45,7 +45,7 @@
+ 
+   # there is some version of librdkafka installed, check that it is what we want
+   AC_RUN_IFELSE([AC_LANG_PROGRAM([
+-    #include <librdkafka/rdkafka.h>
++    #include "rdkafka.h"
+     #include <stdio.h>
+     ],[
+       int version = rd_kafka_version();

--- a/vendor/change_include_path_rdkafka_transports.patch
+++ b/vendor/change_include_path_rdkafka_transports.patch
@@ -1,0 +1,11 @@
+--- lib/transports/bs_transport_kafka.c.org	2023-07-02 18:39:46.030425522 +1000
++++ lib/transports/bs_transport_kafka.c	2023-07-02 18:39:57.976489403 +1000
+@@ -30,7 +30,7 @@
+ #include "bgpstream_log.h"
+ #include "utils.h"
+ #include <assert.h>
+-#include <librdkafka/rdkafka.h>
++#include <rdkafka.h>
+ #include <stdlib.h>
+ #include <string.h>
+ 

--- a/vendor/update_automake_configure_ac.patch
+++ b/vendor/update_automake_configure_ac.patch
@@ -1,0 +1,28 @@
+--- configure.ac.org	2023-07-02 20:47:43.779999603 +1000
++++ configure.ac	2023-07-02 20:51:16.317212298 +1000
+@@ -24,7 +24,7 @@
+ # POSSIBILITY OF SUCH DAMAGE.
+ #
+ 
+-AC_PREREQ([2.68])
++AC_PREREQ([2.71])
+ 
+ 
+ # bgpstream package version
+@@ -32,7 +32,7 @@
+ m4_define([PKG_MID_VERSION],   [1])
+ m4_define([PKG_MINOR_VERSION], [0])
+ 
+-AC_INIT([libbgpstream], PKG_MAJOR_VERSION.PKG_MID_VERSION.PKG_MINOR_VERSION, [bgpstream-info@caida.org])
++AC_INIT([libbgpstream],[PKG_MAJOR_VERSION.PKG_MID_VERSION.PKG_MINOR_VERSION],[bgpstream-info@caida.org])
+ 
+ # libbgpstream shared library version
+ # (no relation to pkg version)
+@@ -62,7 +62,6 @@
+ #
+ DISABLE_RPATH
+ 
+-AM_INIT_AUTOMAKE
+ 
+ AC_CONFIG_MACRO_DIR([m4])
+


### PR DESCRIPTION
- Use rdkafka-sys  crate to provide support for Kakfa
- Use a single function to apply all patches
- Migrate automake configure to new version and use a patch
- Remove `sed` as the syntax is only for GNU sed vs BSD sed.
- Add patch files to fix configure checks and source code for Kafka support