### PR TITLE
Update rerun-if-changed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rdkafka-sys = "4.5.0"
 wandio-sys = "0.2.0"
 
 [build-dependencies]
-bindgen = "0.65.1"
+bindgen = "0.69.1"
 autotools = "0.2"
 rdkafka-sys = "4.5.0"
 wandio-sys = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libbgpstream-sys"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["Brendan Horan"]
 description = "System bindings for bgpstream"

--- a/build.rs
+++ b/build.rs
@@ -134,7 +134,7 @@ fn main() -> std::io::Result<()> {
         .clang_arg(format!("-I{bgpstream_libdir}/"))
         .clang_arg(format!("-I{bgpstream_libdir}/utils"))
         .generate_comments(false)
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(CustomCallbacks(build_output_dir.clone())))
         .generate()
         .expect("Unable to generate bindings");
 
@@ -145,9 +145,31 @@ fn main() -> std::io::Result<()> {
 
     // Regenerate if changed
     println!("cargo:rerun-if-changed=wrapper.h");
+    println!("cargo:rerun-if-changed=vendor/{BGPSTREAM_VERSION}.tgz");
     // Name of the library
     println!("cargo:rustc-link-lib=static=bgpstream");
     // Add in additional search path
     println!("cargo:rustc-link-search=native={bgpstream_libdir}");
     Ok(())
+}
+
+#[derive(Default, Debug)]
+struct CustomCallbacks(String);
+
+impl bindgen::callbacks::ParseCallbacks for CustomCallbacks {
+    fn header_file(&self, filename: &str) {
+        if !filename.starts_with(&self.0) {
+            println!("cargo:rerun-if-changed={}", filename);
+        }
+    }
+
+    fn include_file(&self, filename: &str) {
+        if !filename.starts_with(&self.0) {
+            println!("cargo:rerun-if-changed={}", filename);
+        }
+    }
+
+    fn read_env_var(&self, key: &str) {
+        println!("cargo:rerun-if-env-changed={}", key);
+    }
 }

--- a/build.rs
+++ b/build.rs
@@ -153,7 +153,7 @@ fn main() -> std::io::Result<()> {
     Ok(())
 }
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
 struct CustomCallbacks(String);
 
 impl bindgen::callbacks::ParseCallbacks for CustomCallbacks {


### PR DESCRIPTION
I ran into the issue that cargo always detected a change in header files (like `target/debug/build/libbgpstream-sys-XXXXXXXX/out/libbgpstream-2.2.0/lib/bgpstream.h`. Presumably, these files are modified by one of the commands during the build script. Am I the only one with that issue (working on linux and rustc `1.74.0-nightly`?

Unfortunately, I was unable to figure out why these files were changed (I know that the problem is not the extraction step with `tar`).

Instead, I updated the build script to generate less `cargo:rerun-if-changed`. In fact, those lines are only generated for header- and include files that don't exist within the `OUT_DIR`. In addition, I generate set `rerun-if-changed` for the tarball as well. In doing so, I bumped the bindgen version to 0.69.1.